### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/report-tests.yml
+++ b/.github/workflows/report-tests.yml
@@ -6,6 +6,9 @@ on:
       - completed
 jobs:
   report:
+    permissions:
+      contents: read
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - uses: dorny/test-reporter@v2


### PR DESCRIPTION
Potential fix for [https://github.com/TownSuite/DapperExtras/security/code-scanning/5](https://github.com/TownSuite/DapperExtras/security/code-scanning/5)

In general, the fix is to add an explicit `permissions` block to the workflow or to the individual job(s) so that the `GITHUB_TOKEN` has only the minimal scopes required. For this workflow, the `report` job runs after tests and uses `dorny/test-reporter@v2` to read an uploaded artifact and create a GitHub Check Run with the test results. That means it needs to read repository contents and write checks, but does not need broader write permissions (like pushing commits, modifying issues, etc.).

The best minimal fix without changing functionality is to add a `permissions` block under the `report` job, specifying `contents: read` (to align with normal read-only repo access) and `checks: write` (so it can create/update the test report check). We’ll insert:

```yaml
    permissions:
      contents: read
      checks: write
```

directly under `report:` and above `runs-on:` in `.github/workflows/report-tests.yml`. No other files or imports are involved, and the rest of the workflow remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
