### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   linux-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TownSuite/DapperExtras/security/code-scanning/4](https://github.com/TownSuite/DapperExtras/security/code-scanning/4)

In general, the problem is fixed by adding an explicit `permissions:` block to the workflow or to each job, granting only the minimum required scopes for `GITHUB_TOKEN`. For a simple CI workflow that only checks out code, builds, runs tests, and uploads artifacts—and does not push changes or modify issues/PRs—`contents: read` is typically sufficient.

The best fix here, without changing behavior, is to add a root-level `permissions:` block that applies to all jobs in this workflow. Since the only GitHub operations are `actions/checkout` and `actions/upload-artifact`, the token only needs read access to repository contents; artifact upload does not require additional repository write scopes. We will therefore insert:

```yaml
permissions:
  contents: read
```

between the `on:` section and the `jobs:` section in `.github/workflows/dotnet.yml`. No imports or other definitions are needed, and no existing steps or job definitions need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
